### PR TITLE
Don't count mounted files in the Disk space usage for Jails

### DIFF
--- a/jstats.sh
+++ b/jstats.sh
@@ -39,7 +39,7 @@ printf "\nJails - Disk space usage:"
 printf "\nThis might take a while.."
 sleep 0.5
 printf "\n-------------------------\n"
-jls path | while SUM= read -r line; do du -sh "$line"; done
+jls path | while SUM= read -r line; do du -sh -x "$line"; done
 printf "\n"
 exit 0;
 fi


### PR DESCRIPTION
Jails might have mounted folders (for e.g., for Jellyfin, I have mounted my entire media folder worth TB).  The user will not be interested to count them, when trying to get the size of the jail.